### PR TITLE
Fixed Popen erroneous call and added st

### DIFF
--- a/bin/eve-ng-integration
+++ b/bin/eve-ng-integration
@@ -47,6 +47,8 @@ class Terminal(object):
             return ['xfce4-terminal', '-e']
         elif self._is_command('urxvt'):
             return ['urxvt', '-e']
+        elif self._is_command('st'):
+            return ['st', '-e']
         else:
             return ['xterm', '-e']
 

--- a/bin/eve-ng-integration
+++ b/bin/eve-ng-integration
@@ -53,6 +53,8 @@ class Terminal(object):
     def execute(self, command):
         if isinstance(command, (str)):
             command = command.split('\n')
+            if len(command) == 1:
+                command = command[0].split()
 
         term = self._terminal_emulator_cmd()
 


### PR DESCRIPTION
Hi! 

I've just started using eve-ng for a network class at uni, and I've run into an issue with the client integration. Basically, the telnet opening would cause the program to exit with a code 1. 

I've been able to pin-point that down to the `Popen` call, it seems like it expects every argument to be an item of the list instead of having one with spaces (see: [https://docs.python.org/3/library/subprocess.html#popen-constructor](https://docs.python.org/3/library/subprocess.html#popen-constructor)). I am not a Python specialist, but simply splitting the `command` list if its length equals to one fixed it for me.

I've also added `st` in the term finder since it was not here.

Please tell me if I have accidentally broken something by fixing the issue that way (I've taken an extra security step by splitting only if the length equals 1).

Kind Regards,
Noah
