### PR TITLE
feat: add support for Hyprland and its default terminal kitty

### DIFF
--- a/bin/eve-ng-integration
+++ b/bin/eve-ng-integration
@@ -45,6 +45,8 @@ class Terminal(object):
             return ['pantheon-terminal', '-e']
         elif self._current_desktop('xfce'):
             return ['xfce4-terminal', '-e']
+        elif self._current_desktop('Hyprland'):
+            return ['kitty', 'sh', '-c']
         elif self._current_desktop('sway'):
             return ['foot', 'sh', '-c']
         elif self._is_command('urxvt'):

--- a/bin/eve-ng-integration
+++ b/bin/eve-ng-integration
@@ -45,8 +45,8 @@ class Terminal(object):
             return ['pantheon-terminal', '-e']
         elif self._current_desktop('xfce'):
             return ['xfce4-terminal', '-e']
-        elif self._current_desktop('Hyprland'):
-            return ['kitty', 'sh', '-c']
+        elif self._current_desktop('hyprland'):
+            return ['kitty', '--title', 'eve-ng', 'sh', '-c']
         elif self._current_desktop('sway'):
             return ['foot', 'sh', '-c']
         elif self._is_command('urxvt'):


### PR DESCRIPTION
Added support for the Hyprland desktop environment by including a check for 'Hyprland' and returning the appropriate terminal command using 'kitty'. This ensures compatibility with the Hyprland environment.